### PR TITLE
use jQuery global instead of $ to prevent conflicts

### DIFF
--- a/angular-floatThead.js
+++ b/angular-floatThead.js
@@ -16,7 +16,7 @@
         // Usage:
         // Specify float-thead on any table element and optionally pass through a floatThead options object to initialize the library.
         // Optionally specify ng-model to have the directive watch any objects for changes and call 'reflow' on floatThead.   
-        // You can also manually trigger a reflow by triggering an event on the table element called 'update', eg: $('.table').trigger('update');
+        // You can also manually trigger a reflow by triggering an event on the table element called 'update', eg: jQuery('.table').trigger('update');
         var directive = {
             require: '?ngModel',
             link: link,
@@ -25,12 +25,12 @@
         return directive;
 
         function link(scope, element, attrs, ngModel) {
-            $(element).floatThead(scope.$eval(attrs.floatThead));
+            jQuery(element).floatThead(scope.$eval(attrs.floatThead));
 
             if (ngModel) {
                 // Set $watch to do a deep watch on the ngModel (collection) by specifying true as a 3rd parameter
                 scope.$watch(attrs.ngModel, function () {                    
-                    $(element).floatThead('reflow');
+                    jQuery(element).floatThead('reflow');
                 }, true);
             } else {
                 $log.info('floatThead: ngModel not provided!');
@@ -38,12 +38,12 @@
 
             element.bind('update', function () {                
                 $timeout(function() {
-                    $(element).floatThead('reflow');
+                    jQuery(element).floatThead('reflow');
                 }, 0);
             });
 
             element.bind('$destroy', function() {
-                $(element).floatThead('destroy');
+                jQuery(element).floatThead('destroy');
             });
         }
     }


### PR DESCRIPTION
I do use jQuery.noConflict() http://api.jquery.com/jquery.noconflict/ , and it makes floatHead crash in my app.

This commit replaces all references to $ by jQuery.

Pulling this request as the original floatThead library also follow this principle and don't make use of the global $.