### PR TITLE
Fixing options passing, improving change detection

### DIFF
--- a/angular-floatThead.js
+++ b/angular-floatThead.js
@@ -22,6 +22,12 @@
       scope: {
         floatTheadEnabled: '='
       },
+      controller: function ($scope, $element, $attrs) {
+        // default float-thead-enabled to true if not present
+        if (!$attrs.hasOwnProperty('floatTheadEnabled')) {
+          $scope.floatTheadEnabled = $attrs.floatTheadEnabled = true;
+        }
+      },
       link: link,
       restrict: 'A'
     };
@@ -43,13 +49,13 @@
       });
 
       if (ngModel) {
-        // Set $watch to do a deep watch on the ngModel (collection) by specifying true as a 3rd parameter
-        scope.$watch(attrs.ngModel, function () {
-          //give time for rerender before reflow
+        // hook the model $formatters to get notified when anything changes so we can reflow
+        ngModel.$formatters.push(function () {
+          // give time for rerender before reflow
           $timeout(function() {
             jQuery(element).floatThead('reflow');
-          }, 100);
-        }, true);
+          });
+        });
       } else {
         $log.info('floatThead: ngModel not provided!');
       }

--- a/angular-floatThead.js
+++ b/angular-floatThead.js
@@ -45,7 +45,10 @@
       if (ngModel) {
         // Set $watch to do a deep watch on the ngModel (collection) by specifying true as a 3rd parameter
         scope.$watch(attrs.ngModel, function () {
-          jQuery(element).floatThead('reflow');
+          //give time for rerender before reflow
+          $timeout(function() {
+            jQuery(element).floatThead('reflow');
+          }, 100);
         }, true);
       } else {
         $log.info('floatThead: ngModel not provided!');

--- a/angular-floatThead.js
+++ b/angular-floatThead.js
@@ -20,6 +20,7 @@
     var directive = {
       require: '?ngModel',
       scope: {
+        floatThead: '=?',
         floatTheadEnabled: '=?'
       },
       controller: function ($scope, $element, $attrs) {
@@ -36,13 +37,9 @@
     function link(scope, element, attrs, ngModel) {
       var isEnabled = (scope.floatTheadEnabled === true);
 
-      if (isEnabled) {
-        jQuery(element).floatThead(scope.$eval(attrs.floatThead));
-      }
-
       scope.$watch('floatTheadEnabled', function (newVal) {
         if (newVal === true) {
-          jQuery(element).floatThead(scope.$eval(attrs.floatThead));
+          jQuery(element).floatThead(scope.floatThead);
         } else {
           jQuery(element).floatThead('destroy');
         }

--- a/angular-floatThead.js
+++ b/angular-floatThead.js
@@ -20,7 +20,7 @@
     var directive = {
       require: '?ngModel',
       scope: {
-        floatTheadEnabled: '='
+        floatTheadEnabled: '=?'
       },
       controller: function ($scope, $element, $attrs) {
         // default float-thead-enabled to true if not present

--- a/bower.json
+++ b/bower.json
@@ -25,6 +25,6 @@
     "tests"
   ],
   "dependencies": {
-    "floatThead": "~1.2.8"
+    "floatThead": "^1.2.8"
   }
 }


### PR DESCRIPTION
- $watch was not working correctly for me. I have switched it to use ngModel's $formatters which is more reliable.
- Added default for float-thead-enabled (true) so you can leave it out if you don't need conditional enabling.
- Options weren't properly being passed. Using scope.$eval meant that you couldn't use a bind to a parent scope object. For example: float-thead="floatTheadOptions" didn't work. By defining floatThead as an optional bind and just using scope.floatThead this is now possible and float-thead="{myOption: 123}" still works as well as omitting the options altogether.
- Removed an extraneous check for isEnabled. the $watch will fire automatically on load with the initial value.